### PR TITLE
Simplify the install instruction 

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@ ember-cli addon support for Numeral.js
 # Install
 
 ```bash
-npm install --save-dev ember-cli-numeral;
-bower install --save numeral;
+ember install ember-cli-numeral
 ```
 
 # Usage


### PR DESCRIPTION
I think `ember install ...` is better instruction to install add-on.
